### PR TITLE
Added support for Java9+

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -1,3 +1,4 @@
 [
-	{ "keys": ["ctrl+alt+i"], "command": "java_add_import"}
+	{ "keys": ["ctrl+alt+i"], "command": "java_add_import"},
+	{ "keys": ["ctrl+alt+u"], "command": "update_classes_list"}
 ]

--- a/JavaAddImport.py
+++ b/JavaAddImport.py
@@ -1,22 +1,91 @@
-import sublime, sublime_plugin
-import zipfile
 import os
+import zipfile
+import sublime
+import sublime_plugin
+
+
+def inside_module(filepath, modules):
+        for m in modules:
+                if filepath.startswith(m):
+                        return m
+        return None
+
 
 def get_classes_list(path):
-	if path.endswith(".zip") or path.endswith(".jar"):
-		zipF = zipfile.ZipFile(path, "r")
-		classesList = zipF.namelist()
-		zipF.close()
-		return classesList
-	else:
-		classesList = []
-		for root, dirs, files in os.walk(path):
-			for filename in files:
-				classesList.append((root+"/"+filename)[len(path):])
-		return classesList
+        if path.endswith(".zip") or path.endswith(".jar"):
+                zipF = zipfile.ZipFile(path, "r")
+                
+                modules = []
+                classesList = []
+                for filename in zipF.namelist():
+                    if filename.endswith("module-info.java"):
+                        modules.append(os.path.dirname(filename))
+                        continue
 
-class JavaAddImportCommand(sublime_plugin.TextCommand):
+                    modulepath = inside_module(filename, modules)
+                    classpath = ""
+                    if modulepath:
+                            classpath = filename[len(modulepath) + 1:] #module/
+
+                    if classpath.endswith(".java"):
+                            classpath = classpath[:-5]
+                    elif classpath.endswith(".class"):
+                                    classpath = classpath[:-6]
+                    else:
+                        continue
+
+                    classpath = classpath.replace("/", ".")
+                    classpath = classpath.replace("\\", ".")
+
+                    classesList.append(classpath)
+ 
+                
+                zipF.close()
+                return classesList
+        else:
+                # true if is inside a module
+                # false if is inside a package only (no external module)
+                classesList = []
+                modules = []
+
+                for root, dirs, files in os.walk(path):
+                        for filename in files:
+                                if (filename == "module-info.java"):
+                                        modules.append(root)
+                                        continue
+
+                                modulepath = inside_module(os.path.join(root, filename), modules)
+                                classpath = ""
+                                if modulepath:
+                                        classpath = os.path.join(root, filename)[len(modulepath) + 1:] #module/
+                                else:
+                                        classpath = os.path.join(root, filename)[len(path) + 1:] #path/
+
+                                if classpath.endswith(".java"):
+                                        classpath = classpath[:-5]
+                                elif classpath.endswith(".class"):
+                                        classpath = classpath[:-6]
+                                else:
+                                        # not a java class
+                                        # does not needed
+                                        continue
+
+                                classpath = classpath.replace("/", ".")
+                                classpath = classpath.replace("\\", ".")
+
+                                classesList.append(classpath)
+
+                return classesList
+
+
+classesList = []
+
+
+class UpdateClassesListCommand(sublime_plugin.TextCommand):
 	def run(self, edit):
+		global classesList
+		classesList = []
+			
 		settings = self.view.settings()
 		if not settings.has("java_import_path"):
 			settings = sublime.load_settings("JavaImports.sublime-settings")
@@ -26,39 +95,48 @@ class JavaAddImportCommand(sublime_plugin.TextCommand):
 		if len(settings.get("java_import_path")) == 0:
 			sublime.error_message("You must first define \"java_import_path\" in your settings")
 			return
-		classesList = []
+		
 		for path in settings.get("java_import_path"):
 			classesList = classesList + get_classes_list(path)
 
-		def onDone(className):
-			results = []
-			for name in classesList:
-				if name.endswith("/"+className+".java") or name.endswith("\\"+className+".java") or name.endswith("/"+className+".class") or name.endswith("\\"+className+".class"):
-					result = name.replace("/",".").replace("\\",".").replace(".java","").replace(".class", "")
-					if result.startswith("."):
-						result = result[1:]
-					results.append(result)
 
-			def finishUp(index):
-				if index == -1:
-					return
-				self.view.run_command("java_add_import_insert", {"classpath":results[index]})
+class JavaAddImport(sublime_plugin.TextCommand):
+	# not a singleton
+	# so we should keep classesList outside
 
-			if len(results) == 1:
-				finishUp(0)
-			elif len(results) > 1:
-				self.view.window().show_quick_panel(results, finishUp)
-			else:
-				sublime.error_message("There is no such class in \"java_import_path\"")
+	def __init__(self, *args):
+		self.results = None
+		super().__init__(*args)
 
+
+	def finishUp(self, index):
+		if index == -1:
+			return
+		self.view.run_command("java_add_import_insert", {"classpath":self.results[index]})
+
+
+	def onDone(self, className):
+		self.results = [c for c in classesList if c.split(".")[-1].startswith(className)]
+
+		if len(self.results) == 1:
+			self.finishUp(0)
+		elif len(self.results) > 1:
+			self.view.window().show_quick_panel(self.results, self.finishUp)
+		else:
+			sublime.error_message("There is no such class in \"java_import_path\"." + \
+				"Try using ctrl+alt+u to update classes list or add needed library path to settings of plugin")
+
+
+	def run(self, edit):
 		allEmpty = True
 		for sel in self.view.sel():
 			if sel.empty():
 				continue
-			onDone(self.view.substr(sel))
+			self.onDone(self.view.substr(sel))
 			allEmpty = False
 		if allEmpty:
-			self.view.window().show_input_panel("Class name: ", "", onDone, None, None)
+			self.view.window().show_input_panel("Class name: ", "", self.onDone, None, None)
+
 
 class JavaAddImportInsertCommand(sublime_plugin.TextCommand):
 		def run(self, edit, classpath):

--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -12,7 +12,7 @@
                 "children":
                 [
                     {
-                        "caption": "YourMom",
+                        "caption": "JavaImports",
                         "children":
                         [
                             {

--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -12,7 +12,7 @@
                 "children":
                 [
                     {
-                        "caption": "JavaImports",
+                        "caption": "YourMom",
                         "children":
                         [
                             {


### PR DESCRIPTION
Added support of packages including Java9 modules.

Java9 came with modules. Now, even from packages from standard library lie inside a module. For example, 
`java.io` package lies inside a `java.base` module along with many other packages from std library. So, now the source directory of, for example, `java.io.InputStreamReader` class is `java.base/java/io/InputStreamReader`. Your code would do such an imports:
```
import java.base.java.io.InputStreamReader
```
(not exactly that, it will be `java.base.io.InputStream` due to a little bug, but never mind)
But it should be:
```
import java.io.InputStreamReader
```
omitting the module name. This problem will appear with every Java library which contains Java modules(Standard Java Library, Spring, etc.). 

I've solved this issue. Please see my contribution.

Also, I've added these:

- Platform-independent path concatenation using os.path.join. 
- Class storage is now statically cached inside a program and does not need to be updated every time the JavaAddImportCommand is invoked(like was in previous version). 
- Added a command to update classpath storage(cache). Refactored a bit.